### PR TITLE
Add my VM claim

### DIFF
--- a/claims/my-vm.yaml
+++ b/claims/my-vm.yaml
@@ -1,0 +1,9 @@
+apiVersion: demo.upbound.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: my-vm-from-argo-git
+  namespace: default
+spec:
+  id: my-vm-from-argo-git
+  parameters:
+    location: East US


### PR DESCRIPTION
This PR adds a Crossplane Composite Resource Claim (XRC) for a new VM, to be synced by Argo and submitted to my managed control plane running in Upbound